### PR TITLE
Add support to handle results coming back from browser

### DIFF
--- a/Source/Facebook.Client-Universal/Facebook.Client-Universal.WindowsPhone/Facebook.Client-Universal.WindowsPhone.csproj
+++ b/Source/Facebook.Client-Universal/Facebook.Client-Universal.WindowsPhone/Facebook.Client-Universal.WindowsPhone.csproj
@@ -198,6 +198,9 @@
     <Compile Include="..\..\Facebook.Client\FacebookSessionLocalSettingsCacheProvider.cs">
       <Link>FacebookSessionLocalSettingsCacheProvider.cs</Link>
     </Compile>
+    <Compile Include="..\..\Facebook.Client\FacebookUriMapper.cs">
+      <Link>FacebookUriMapper.cs</Link>
+    </Compile>
     <Compile Include="..\..\Facebook.Client\GraphLocation.cs">
       <Link>GraphLocation.cs</Link>
     </Compile>

--- a/Source/Facebook.Client-WP8/Facebook.Client-WP8.csproj
+++ b/Source/Facebook.Client-WP8/Facebook.Client-WP8.csproj
@@ -195,6 +195,9 @@
     <Compile Include="..\Facebook.Client\FacebookSessionIsolatedStorageCacheProvider.cs">
       <Link>FacebookSessionIsolatedStorageCacheProvider.cs</Link>
     </Compile>
+    <Compile Include="..\Facebook.Client\FacebookUriMapper.cs">
+      <Link>FacebookUriMapper.cs</Link>
+    </Compile>
     <Compile Include="..\Facebook.Client\GraphLocation.cs">
       <Link>GraphLocation.cs</Link>
     </Compile>
@@ -229,7 +232,6 @@
     <Compile Include="AppAuthenticationHelper.cs" />
     <Compile Include="Controls\Converters\ImageSourceUriConverter.cs" />
     <Compile Include="Controls\Picker\Picker.cs" />
-    <Compile Include="FacebookUriMapper.cs" />
     <Compile Include="Resources\AppResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/Source/Facebook.Client-WP8/FacebookUriMapper.cs
+++ b/Source/Facebook.Client-WP8/FacebookUriMapper.cs
@@ -12,39 +12,187 @@ namespace Facebook.Client
 {
     public class FacebookUriMapper : UriMapperBase
     {
+        private enum FacebookUriType
+        {
+            Login,
+            AppRequest,
+            Feed
+        }
+
         public override Uri MapUri(Uri uri)
         {
-            var tempUri = System.Net.HttpUtility.UrlDecode(uri.ToString());
+            var tempUri = uri.ToString();
+            FacebookUriType uriType = FacebookUriType.Login;
+#if WP8
+            if (tempUri.StartsWith(string.Format("/Protocol?encodedLaunchUri={0}", Session.LoginRedirectUri)))
+                uriType = FacebookUriType.Login;
+            else if (tempUri.StartsWith(string.Format("/Protocol?encodedLaunchUri={0}", Session.AppRequestRedirectUri)))
+                uriType = FacebookUriType.AppRequest;
+            else if (tempUri.StartsWith(string.Format("/Protocol?encodedLaunchUri={0}", Session.FeedRedirectUri)))
+                uriType = FacebookUriType.Feed;
+#else
+            if (tempUri.StartsWith(WebUtility.UrlDecode(Session.LoginRedirectUri)))
+                uriType = FacebookUriType.Login;
+            else if (tempUri.StartsWith(WebUtility.UrlDecode(Session.AppRequestRedirectUri)))
+                uriType = FacebookUriType.AppRequest;
+            else if (tempUri.StartsWith(WebUtility.UrlDecode(Session.FeedRedirectUri)))
+                uriType = FacebookUriType.Feed;
+#endif
 
-            try
+            if (uriType == FacebookUriType.Login)
             {
-                AccessTokenData session = new AccessTokenData();
-                session.ParseQueryString(HttpUtility.UrlDecode(uri.ToString()));
-                if (!String.IsNullOrEmpty(session.AccessToken))
+                try
                 {
-                    var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));
-                    task.Wait();
-                    
+                    AccessTokenData session = new AccessTokenData();
+                    session.ParseQueryString(HttpUtility.UrlDecode(uri.ToString()));
+                    if (!String.IsNullOrEmpty(session.AccessToken))
+                    {
+                        var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));
+                        task.Wait();
 
+                        session.AppId = task.Result;
+                        Session.ActiveSession.CurrentAccessTokenData = session;
 
-                    session.AppId = task.Result;
-                    Session.ActiveSession.CurrentAccessTokenData = session;
+                        // trigger the event handler with the session
+                        if (Session.OnFacebookAuthenticationFinished != null)
+                        {
+                            Session.OnFacebookAuthenticationFinished(session);
+                        }
 
-                    // trigger the event handler with the session
+                        if (Session.OnSessionStateChanged != null)
+                        {
+                            Session.OnSessionStateChanged(LoginStatus.LoggedIn);
+                        }
+                    }
+                }
+                catch (Facebook.FacebookOAuthException exc)
+                {
+                    // fire the authentication finished handler with the exception 
                     if (Session.OnFacebookAuthenticationFinished != null)
                     {
-                        Session.OnFacebookAuthenticationFinished(session);
-                    }
-
-                    if (Session.OnSessionStateChanged != null)
-                    {
-                        Session.OnSessionStateChanged(LoginStatus.LoggedIn);
+                        Session.OnFacebookAuthenticationFinished(null);
                     }
                 }
             }
-            catch (Facebook.FacebookOAuthException exc)
+            else if (uriType == FacebookUriType.AppRequest)
             {
+                // parsing query string to get request id and facebook ids of the people the request has been sent to
+                // or error code and error messages
+                FBResult fbResult = new FBResult();
 
+                try
+                {
+                    fbResult.Json = new JsonObject();
+
+#if WP8
+                    string queryString = GetQueryStringFromUri(HttpUtility.UrlDecode(tempUri));
+#else
+                    string queryString = GetQueryStringFromUri("/Protocol?encodedLaunchUri=" + WebUtility.UrlDecode(tempUri));
+#endif
+
+                    string[] queries = queryString.Split('&');
+                    if (queries.Length > 0)
+                    {
+                        string request = string.Empty;
+                        List<string> toList = new List<string>();
+
+                        foreach (string query in queries)
+                        {
+                            string[] keyValue = query.Split('=');
+                            if (keyValue.Length >= 2)
+                            {
+                                if (keyValue[0].Contains("request"))
+                                    request = keyValue[1];
+                                else if (keyValue[0].Contains("to"))
+                                    toList.Add(keyValue[1]);
+                                else if (keyValue[0].Contains("error_code"))
+                                    fbResult.Error = keyValue[1];
+                                else if (keyValue[0].Contains("error_message"))
+                                    fbResult.Text = keyValue[1].Replace('+', ' ');
+                            }
+                        }
+                        if (!string.IsNullOrWhiteSpace(request))
+                        {
+                            fbResult.Json.Add(new KeyValuePair<string, object>("request", request));
+                            fbResult.Json.Add(new KeyValuePair<string, object>("to", toList));
+                        }
+
+                        // If there's no error, assign the success text
+                        if (string.IsNullOrWhiteSpace(fbResult.Text))
+                            fbResult.Text = "Success";
+                    }
+                }
+                catch
+                {
+                    fbResult.Error = "Failure";
+                    fbResult.Text = "AppRequest cancelled or ended with exceptional state";
+                }
+
+                // trigger the event handler with the session
+                if (Session.OnFacebookAppRequestFinished != null)
+                {
+                    Session.OnFacebookAppRequestFinished(fbResult);
+                }
+            }
+            else if (uriType == FacebookUriType.Feed)
+            {
+                // parsing query string to get request id and facebook ids of the people the request has been sent to
+                // or error code and error messages
+                FBResult fbResult = new FBResult();
+
+                try
+                {
+                    // parsing query string to get request id and facebook ids of the people the request has been sent to
+                    // or error code and error messages
+                    fbResult.Json = new JsonObject();
+
+#if WP8
+                    string queryString = GetQueryStringFromUri(HttpUtility.UrlDecode(tempUri));
+#else
+                    string queryString = GetQueryStringFromUri("/Protocol?encodedLaunchUri=" + WebUtility.UrlDecode(tempUri));
+#endif
+
+                    string[] queries = queryString.Split('&');
+                    if (queries.Length > 0)
+                    {
+                        string postId = string.Empty;
+                        List<string> toList = new List<string>();
+
+                        foreach (string query in queries)
+                        {
+                            string[] keyValue = query.Split('=');
+                            if (keyValue.Length >= 2)
+                            {
+                                if (keyValue[0].Contains("post_id"))
+                                    postId = keyValue[1];
+                                else if (keyValue[0].Contains("error_code"))
+                                    fbResult.Error = keyValue[1];
+                                else if (keyValue[0].Contains("error_msg"))
+                                    fbResult.Text = keyValue[1].Replace('+', ' ');
+                            }
+                        }
+                        if (!string.IsNullOrWhiteSpace(postId))
+                        {
+                            fbResult.Json.Add(new KeyValuePair<string, object>("post_id", postId));
+                        }
+                    }
+
+                    // If there's no error, assign the success text
+                    if (string.IsNullOrWhiteSpace(fbResult.Text))
+                        fbResult.Text = "Success";
+
+                }
+                catch
+                {
+                    fbResult.Error = "Failure";
+                    fbResult.Text = "Feed cancelled or ended with exceptional state";
+                }
+
+                // trigger the event handler with the session
+                if (Session.OnFacebookFeedFinished != null)
+                {
+                    Session.OnFacebookFeedFinished(fbResult);
+                }
             }
 
             if (uri.ToString().StartsWith("/Protocol"))
@@ -62,6 +210,27 @@ namespace Facebook.Client
 
             // Otherwise perform normal launch.
             return uri;
+        }
+
+        private static string GetQueryStringFromUri(string uri)
+        {
+            int questionMarkIndex = uri.LastIndexOf("?", StringComparison.Ordinal);
+            if (questionMarkIndex == -1)
+            {
+                // if no questionmark found, this is just a queryString
+                return uri;
+            }
+
+            string queryString = string.Empty;
+
+            int endIndex = uri.LastIndexOf("#_=_");
+            if (endIndex == -1)
+                queryString = uri.Substring(questionMarkIndex, uri.Length - questionMarkIndex);
+            else
+                queryString = uri.Substring(questionMarkIndex, endIndex - questionMarkIndex);
+            
+            queryString = queryString.Replace("#", string.Empty).Replace("?", string.Empty);
+            return queryString;
         }
     }
 }

--- a/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
+++ b/Source/Facebook.Client/Controls/WebDialog/WebDialogUserControl.xaml.cs
@@ -203,7 +203,7 @@ namespace Facebook.Client.Controls.WebDialog
         }
 
 
-        internal static void ShowAppRequestDialogViaBrowser(string message, string title, List<string> idList)
+        internal static void ShowAppRequestDialogViaBrowser(string message, string title, List<string> idList, string data)
         {
             var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));
             task.Wait();
@@ -216,15 +216,15 @@ namespace Facebook.Client.Controls.WebDialog
                     idBuilder.Append(id + ",");
                 }
             }
-            
-            Launcher.LaunchUriAsync(new Uri(String.Format("https://m.facebook.com/v2.1/dialog/apprequests?access_token={0}&redirect_uri=fb{2}%3A%2F%2Fsuccess&app_id={1}&message={2}&display=touch{3}&title={4}", Session.ActiveSession.CurrentAccessTokenData.AccessToken, task.Result, task.Result, idBuilder.Length > 4 ? idBuilder.ToString() : String.Empty, title)));
+
+            Launcher.LaunchUriAsync(new Uri(String.Format("https://m.facebook.com/v2.1/dialog/apprequests?access_token={0}&redirect_uri={2}&app_id={1}&message={5}&display=touch{3}&title={4}&data={6}", Session.ActiveSession.CurrentAccessTokenData.AccessToken, task.Result, Session.AppRequestRedirectUri, idBuilder.Length > 4 ? idBuilder.ToString() : String.Empty, title, message, data)));
         }
 
         internal static void ShowFeedDialogViaBrowser(string toId = "", string link = "", string linkName = "", string linkCaption = "", string linkDescription = "", string picture = "")
         {
             var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));
             task.Wait();
-            Launcher.LaunchUriAsync(new Uri(String.Format("https://m.facebook.com/v2.1/dialog/feed?access_token={0}&redirect_uri=fb{2}%3A%2F%2Fsuccess&app_id={1}&display=touch&to={3}&link={4}&name={5}&caption={6}&description={7}&picture={8}", Session.ActiveSession.CurrentAccessTokenData.AccessToken, task.Result, task.Result, toId, link, linkName, linkCaption, linkDescription, picture)));
+            Launcher.LaunchUriAsync(new Uri(String.Format("https://m.facebook.com/v2.1/dialog/feed?access_token={0}&redirect_uri={2}&app_id={1}&display=touch&to={3}&link={4}&name={5}&caption={6}&description={7}&picture={8}", Session.ActiveSession.CurrentAccessTokenData.AccessToken, task.Result, Session.FeedRedirectUri, toId, link, linkName, linkCaption, linkDescription, picture)));
         }
 
 

--- a/Source/Facebook.Client/FacebookUriMapper.cs
+++ b/Source/Facebook.Client/FacebookUriMapper.cs
@@ -1,16 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Navigation;
 using System.Net;
-using Microsoft.Phone.Controls;
+#if WP8
+using System.Windows.Navigation;
+#endif
 
 namespace Facebook.Client
 {
+#if WP8
     public class FacebookUriMapper : UriMapperBase
+#else
+    public class FacebookUriMapper
+#endif
     {
         private enum FacebookUriType
         {
@@ -19,7 +21,11 @@ namespace Facebook.Client
             Feed
         }
 
+#if WP8
         public override Uri MapUri(Uri uri)
+#else
+        public Uri MapUri(Uri uri)
+#endif
         {
             var tempUri = uri.ToString();
             FacebookUriType uriType = FacebookUriType.Login;
@@ -44,7 +50,7 @@ namespace Facebook.Client
                 try
                 {
                     AccessTokenData session = new AccessTokenData();
-                    session.ParseQueryString(HttpUtility.UrlDecode(uri.ToString()));
+                    session.ParseQueryString(WebUtility.UrlDecode(uri.ToString()));
                     if (!String.IsNullOrEmpty(session.AccessToken))
                     {
                         var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));

--- a/Source/Facebook.Client/Session.cs
+++ b/Source/Facebook.Client/Session.cs
@@ -90,12 +90,20 @@ namespace Facebook.Client
     }
 
     public delegate void FacebookAuthenticationDelegate(AccessTokenData session);
+    public delegate void FacebookDelegate(FBResult result);
 
     public delegate void WebDialogFinishedDelegate(WebDialogResult result);
 
     public delegate void DismissDialogDelegate(Uri uri);
 
     internal delegate void SessionStateChanged(LoginStatus status);
+
+    public class FBResult
+    {
+        public string Error { get; set; }
+        public string Text { get; set; }
+        public JsonObject Json { get; set; }
+    }
 
     public class Session
     {
@@ -119,6 +127,9 @@ namespace Facebook.Client
         public static Session ActiveSession = new Session();
 
         public static FacebookAuthenticationDelegate OnFacebookAuthenticationFinished;
+        public static FacebookDelegate OnFacebookAppRequestFinished;
+        public static FacebookDelegate OnFacebookFeedFinished;
+
         internal static SessionStateChanged OnSessionStateChanged;
 
         /// <summary>
@@ -128,6 +139,19 @@ namespace Facebook.Client
         {
             get { return Session.ActiveSession.CurrentAccessTokenData.AppId; }
         }
+
+        public static string LoginRedirectUri
+        {
+            get
+            {
+                var task = Task.Run(async () => await AppAuthenticationHelper.GetFacebookConfigValue("Facebook", "AppId"));
+                task.Wait();
+                return string.Format("fb{0}%3A%2F%2Fauthorize", task.Result);
+            }
+        }
+        public static string AppRequestRedirectUri { get { return string.Format("fb{0}%3A%2F%2Fapprequest", AppId); } }
+        public static string FeedRedirectUri { get { return string.Format("fb{0}%3A%2F%2Ffeed", AppId); } }
+
         public bool LoginInProgress { get; set; }
 
         internal string RedirectPageOnSuccess = "MainPage.xaml";
@@ -236,10 +260,9 @@ namespace Facebook.Client
 
 
 #if !WINDOWS
-        public static void ShowAppRequestDialogViaBrowser(string message, string title, List<string> idList=null)
+        public static void ShowAppRequestDialogViaBrowser(string message, string title = "", List<string> idList=null, string data = "")
         {
-            // TODO: Setup callback and message
-            WebDialogUserControl.ShowAppRequestDialogViaBrowser(message, title, idList);
+            WebDialogUserControl.ShowAppRequestDialogViaBrowser(message, title, idList, data);
         }
 
         public static void ShowFeedDialogViaBrowser(string toId = "", string link = "", string linkName = "", string linkCaption = "", string linkDescription = "", string picture = "")
@@ -447,8 +470,8 @@ namespace Facebook.Client
                     Uri uri =
                         new Uri(
                             String.Format(
-                                "https://m.facebook.com/v2.1/dialog/oauth?redirect_uri={0}%3A%2F%2Fauthorize&display=touch&state=%7B%220is_active_session%22%3A1%2C%22is_open_session%22%3A1%2C%22com.facebook.sdk_client_state%22%3A1%2C%223_method%22%3A%22browser_auth%22%7D&scope={2}&type=user_agent&client_id={1}&sdk=ios",
-                                String.Format("fb{0}", appId), appId, permissions), UriKind.Absolute);
+                                "https://m.facebook.com/v2.1/dialog/oauth?redirect_uri={0}&display=touch&state=%7B%220is_active_session%22%3A1%2C%22is_open_session%22%3A1%2C%22com.facebook.sdk_client_state%22%3A1%2C%223_method%22%3A%22browser_auth%22%7D&scope={2}&type=user_agent&client_id={1}&sdk=ios",
+                                LoginRedirectUri, appId, permissions), UriKind.Absolute);
                     
                     Launcher.LaunchUriAsync(uri);
                     break;


### PR DESCRIPTION
Modified redirect uri for the ViaBrowser calls, allow UriMapper to differentiate between Login, AppRequest and Feed results coming back from browser.
